### PR TITLE
Settings

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-04-09T13:10:29.546263200Z">
+        <DropdownSelection timestamp="2025-04-09T13:38:12.783241200Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Deni\.android\avd\Pixel_3_API_30.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R58R84YNRWT" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,7 @@ dependencies {
 
     // ViewModelScope
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
 }

--- a/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : ComponentActivity() {
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
                 val reminderNotification = ReminderNotification(applicationContext)
-                reminderNotification.scheduleNotificationDefaultTime()
+                reminderNotification.scheduleNotification()
             }
 
             lifecycleScope.launch {

--- a/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : ComponentActivity() {
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
                 val reminderNotification = ReminderNotification(applicationContext)
-                reminderNotification.scheduleNotification()
+                reminderNotification.scheduleNotificationDefaultTime()
             }
 
             lifecycleScope.launch {

--- a/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity : ComponentActivity() {
                         },
                         title = {
                             Text(
-                                text = "Notifications",
+                                text = stringResource(R.string.notifications),
                                 textAlign = TextAlign.Center,
                                 modifier = Modifier.fillMaxWidth()
                             )

--- a/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainActivity.kt
@@ -1,23 +1,101 @@
 package com.example.flashcardsapp
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.flashcardsapp.notification.ReminderNotification
 import com.example.flashcardsapp.ui.theme.FlashCardsAppTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+    private lateinit var viewModel: MainViewModel
+
+    // field in class cuz it needs to be registered before STARTED
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                val reminderNotification = ReminderNotification(applicationContext)
+                reminderNotification.scheduleNotification()
+            }
+
+            lifecycleScope.launch {
+                viewModel.markAskedForPermissionOnce(applicationContext, isGranted)
+            }
+
+            val showRationale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                false
+            }
+
+            viewModel.onPermissionResult(showRationale)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // temporarily schedule notifications here. will be moved when settings screen is done
-        val reminderNotification = ReminderNotification(applicationContext)
-        reminderNotification.scheduleNotification()
-
         setContent {
             FlashCardsAppTheme {
+                viewModel = viewModel()
+
+                LaunchedEffect(Unit) {
+                    viewModel.askForPermission(applicationContext, requestPermissionLauncher)
+                }
+
+                if (viewModel.shouldShowDialog) {
+                    AlertDialog(
+                        onDismissRequest = viewModel::dismissDialog,
+                        confirmButton = {
+                            Column(
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                HorizontalDivider()
+                                TextButton(
+                                    onClick = viewModel::dismissDialog,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.confirm),
+                                        fontWeight = FontWeight.Bold,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
+                        },
+                        title = {
+                            Text(
+                                text = "Notifications",
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        },
+                        text = {
+                            Text(
+                                text = "Memora sends you only one notification per day to remind you " +
+                                        "to study. You can always enable notifications in settings."
+                            )
+                        },
+                    )
+                }
+
                 FlashCardApp()
             }
         }

--- a/app/src/main/java/com/example/flashcardsapp/MainViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainViewModel.kt
@@ -56,6 +56,7 @@ class MainViewModel : ViewModel() {
         applicationContext.dataStore.edit { prefs ->
             prefs[SettingsKeys.hasRequestPermissionOnceKey] = true
             prefs[SettingsKeys.notificationsEnabledKey] = isGranted
+            prefs[SettingsKeys.notificationPermissionGrantedKey] = isGranted
         }
     }
 }

--- a/app/src/main/java/com/example/flashcardsapp/MainViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/MainViewModel.kt
@@ -1,0 +1,61 @@
+package com.example.flashcardsapp
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.result.ActivityResultLauncher
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.ViewModel
+import com.example.flashcardsapp.ui.settings.SettingsKeys
+import com.example.flashcardsapp.ui.settings.dataStore
+import kotlinx.coroutines.flow.first
+
+class MainViewModel : ViewModel() {
+    var shouldShowDialog by mutableStateOf(false)
+        private set
+
+    fun dismissDialog() {
+        shouldShowDialog = false
+    }
+
+    fun onPermissionResult(shouldShowRationale: Boolean) {
+        shouldShowDialog = shouldShowRationale
+    }
+
+    suspend fun askForPermission(
+        applicationContext: Context,
+        requestPermissionLauncher: ActivityResultLauncher<String>
+    ) {
+        applicationContext.dataStore.edit {
+            if (!it.contains(SettingsKeys.hasRequestPermissionOnceKey)) {
+                it[SettingsKeys.hasRequestPermissionOnceKey] = false
+            }
+        }
+
+        // check if it has already been asked for permissions and if not, then that's the first time
+        // the app has been started, so ask for permissions
+        if (applicationContext.dataStore.data.first()[SettingsKeys.hasRequestPermissionOnceKey] == false) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (ContextCompat.checkSelfPermission(
+                        applicationContext,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    ) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        }
+    }
+
+    suspend fun markAskedForPermissionOnce(applicationContext: Context, isGranted: Boolean) {
+        applicationContext.dataStore.edit { prefs ->
+            prefs[SettingsKeys.hasRequestPermissionOnceKey] = true
+            prefs[SettingsKeys.notificationsEnabledKey] = isGranted
+        }
+    }
+}

--- a/app/src/main/java/com/example/flashcardsapp/notification/NotificationUtils.kt
+++ b/app/src/main/java/com/example/flashcardsapp/notification/NotificationUtils.kt
@@ -1,0 +1,22 @@
+package com.example.flashcardsapp.notification
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.example.flashcardsapp.FlashCardApplication
+
+object NotificationUtils {
+    fun getNotificationPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, ReminderReceiver::class.java)
+        return PendingIntent.getBroadcast(
+            context,
+            FlashCardApplication.OPEN_APP_REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    fun getAlarmManager(context: Context): AlarmManager =
+        context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+}

--- a/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
+++ b/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
@@ -54,7 +54,7 @@ class ReminderNotification(private val context: Context) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
         val initialDate = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 10)
+            set(Calendar.HOUR_OF_DAY, 9)
             set(Calendar.MINUTE, 0)
         }
         alarmManager.setRepeating(

--- a/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
+++ b/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat
 import com.example.flashcardsapp.FlashCardApplication
 import com.example.flashcardsapp.MainActivity
 import com.example.flashcardsapp.R
+import java.time.LocalTime
 import java.util.Calendar
 
 class ReminderNotification(private val context: Context) {
@@ -42,24 +43,35 @@ class ReminderNotification(private val context: Context) {
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
 
-    fun scheduleNotification() {
-        val intent = Intent(context, ReminderReceiver::class.java)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            FlashCardApplication.OPEN_APP_REQUEST_CODE,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE
-        )
+    fun scheduleNotificationDefaultTime() {
+        val pendingIntent = NotificationUtils.getNotificationPendingIntent(context)
 
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val alarmManager = NotificationUtils.getAlarmManager(context)
 
-        val initialDate = Calendar.getInstance().apply {
+        val defaultTime = Calendar.getInstance().apply {
             set(Calendar.HOUR_OF_DAY, 9)
             set(Calendar.MINUTE, 0)
         }
         alarmManager.setRepeating(
             AlarmManager.RTC_WAKEUP,
-            initialDate.timeInMillis,
+            defaultTime.timeInMillis,
+            AlarmManager.INTERVAL_DAY,
+            pendingIntent
+        )
+    }
+
+    fun scheduleNotification(time: LocalTime) {
+        val pendingIntent = NotificationUtils.getNotificationPendingIntent(context)
+
+        val alarmManager = NotificationUtils.getAlarmManager(context)
+
+        val scheduleTime = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, time.hour)
+            set(Calendar.MINUTE, time.minute)
+        }
+        alarmManager.setRepeating(
+            AlarmManager.RTC_WAKEUP,
+            scheduleTime.timeInMillis,
             AlarmManager.INTERVAL_DAY,
             pendingIntent
         )

--- a/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
+++ b/app/src/main/java/com/example/flashcardsapp/notification/ReminderNotification.kt
@@ -43,24 +43,7 @@ class ReminderNotification(private val context: Context) {
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
 
-    fun scheduleNotificationDefaultTime() {
-        val pendingIntent = NotificationUtils.getNotificationPendingIntent(context)
-
-        val alarmManager = NotificationUtils.getAlarmManager(context)
-
-        val defaultTime = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 9)
-            set(Calendar.MINUTE, 0)
-        }
-        alarmManager.setRepeating(
-            AlarmManager.RTC_WAKEUP,
-            defaultTime.timeInMillis,
-            AlarmManager.INTERVAL_DAY,
-            pendingIntent
-        )
-    }
-
-    fun scheduleNotification(time: LocalTime) {
+    fun scheduleNotification(time: LocalTime = LocalTime.of(9, 0)) {
         val pendingIntent = NotificationUtils.getNotificationPendingIntent(context)
 
         val alarmManager = NotificationUtils.getAlarmManager(context)

--- a/app/src/main/java/com/example/flashcardsapp/ui/FlashCardAppViewModelProvider.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/FlashCardAppViewModelProvider.kt
@@ -29,6 +29,7 @@ class CustomFactories {
         fun standardStudyFactory(deckId: Int): ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 StandardStudyViewModel(
+                    applicationContext = flashCardApplication().applicationContext,
                     deckId = deckId,
                     cardRepository = flashCardApplication().container.cardRepository
                 )
@@ -38,6 +39,7 @@ class CustomFactories {
         fun timedStudyFactory(deckId: Int): ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 TimedStudyViewModel(
+                    applicationContext = flashCardApplication().applicationContext,
                     deckId = deckId,
                     cardRepository = flashCardApplication().container.cardRepository
                 )
@@ -47,6 +49,7 @@ class CustomFactories {
         fun advancedStudyFactory(deckId: Int): ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 AdvancedStudyViewModel(
+                    applicationContext = flashCardApplication().applicationContext,
                     deckId = deckId,
                     cardRepository = flashCardApplication().container.cardRepository
                 )

--- a/app/src/main/java/com/example/flashcardsapp/ui/FlashCardAppViewModelProvider.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/FlashCardAppViewModelProvider.kt
@@ -10,6 +10,7 @@ import com.example.flashcardsapp.ui.card.AddCardsViewModel
 import com.example.flashcardsapp.ui.card.CardListViewModel
 import com.example.flashcardsapp.ui.card.EditCardViewModel
 import com.example.flashcardsapp.ui.deck.DeckListViewModel
+import com.example.flashcardsapp.ui.settings.SettingsViewModel
 import com.example.flashcardsapp.ui.study.AdvancedStudyViewModel
 import com.example.flashcardsapp.ui.study.StandardStudyViewModel
 import com.example.flashcardsapp.ui.study.TimedStudyViewModel
@@ -72,6 +73,10 @@ object FlashCardAppViewModelProvider {
             EditCardViewModel(
                 flashCardApplication().container.cardRepository
             )
+        }
+
+        initializer {
+            SettingsViewModel(flashCardApplication().applicationContext)
         }
     }
 }

--- a/app/src/main/java/com/example/flashcardsapp/ui/deck/DeckListScreen.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/deck/DeckListScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Card
@@ -98,6 +99,7 @@ private const val DEFAULT_FILE_NAME = "exported_decks.json"
 @Composable
 fun DeckListScreen(
     navigateToDeck: (Int) -> Unit,
+    onNavigateToSettings: () -> Unit,
     viewModel: DeckListViewModel = viewModel(factory = FlashCardAppViewModelProvider.Factory)
 ) {
     val deckListUiState by viewModel.deckListUiState.collectAsState()
@@ -206,14 +208,26 @@ fun DeckListScreen(
                     AnimatedVisibility(
                         visible = !inSelectionMode
                     ) {
-                        IconButton(
-                            onClick = { launcherImport.launch(arrayOf(APPLICATION_JSON)) }
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.import_icon),
-                                contentDescription = stringResource(R.string.import_icon),
-                                modifier = Modifier.size(dimensionResource(R.dimen.icon_top_bar_size))
-                            )
+                        Row {
+                            IconButton(
+                                onClick = { launcherImport.launch(arrayOf(APPLICATION_JSON)) }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.import_icon),
+                                    contentDescription = stringResource(R.string.import_icon),
+                                    modifier = Modifier.size(dimensionResource(R.dimen.icon_top_bar_size))
+                                )
+                            }
+
+                            IconButton(
+                                onClick = onNavigateToSettings
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.Settings,
+                                    contentDescription = stringResource(R.string.settings_icon),
+                                    modifier = Modifier.size(dimensionResource(R.dimen.icon_top_bar_size))
+                                )
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/com/example/flashcardsapp/ui/navigation/Destinations.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/navigation/Destinations.kt
@@ -22,3 +22,6 @@ data class TimedStudyDestination(val deckId: Int = 0)
 
 @Serializable
 data class AdvancedStudyDestination(val deckId: Int = 0)
+
+@Serializable
+object SettingsDestination

--- a/app/src/main/java/com/example/flashcardsapp/ui/navigation/FlashCardNavHost.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/navigation/FlashCardNavHost.kt
@@ -10,6 +10,7 @@ import com.example.flashcardsapp.ui.card.AddCardsScreen
 import com.example.flashcardsapp.ui.card.CardListScreen
 import com.example.flashcardsapp.ui.card.EditCardScreen
 import com.example.flashcardsapp.ui.deck.DeckListScreen
+import com.example.flashcardsapp.ui.settings.SettingsScreen
 import com.example.flashcardsapp.ui.study.AdvancedStudyScreen
 import com.example.flashcardsapp.ui.study.StandardStudyScreen
 import com.example.flashcardsapp.ui.study.TimedStudyScreen
@@ -25,9 +26,14 @@ fun FlashCardNavHost(
         modifier = modifier
     ) {
         composable<StartDestination> {
-            DeckListScreen(navigateToDeck = { deckId ->
-                navController.navigate(CardListDestination(deckId))
-            })
+            DeckListScreen(
+                navigateToDeck = { deckId ->
+                    navController.navigate(CardListDestination(deckId))
+                },
+                onNavigateToSettings = {
+                    navController.navigate(SettingsDestination)
+                }
+            )
         }
 
         composable<CardListDestination> {
@@ -93,6 +99,10 @@ fun FlashCardNavHost(
                 deckId = destination.deckId,
                 onNavigateBackUp = { navController.navigateUp() }
             )
+        }
+
+        composable<SettingsDestination> {
+            SettingsScreen(onNavigateBackUp = { navController.navigateUp() })
         }
     }
 }

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
@@ -1,0 +1,218 @@
+package com.example.flashcardsapp.ui.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.flashcardsapp.ui.DefaultTopBar
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun SettingsScreen(
+    onNavigateBackUp: () -> Unit,
+) {
+    val standardLimit = remember { mutableStateOf("") }
+    val timedLimit = remember { mutableStateOf("") }
+    val advancedLimit = remember { mutableStateOf("") }
+
+    val timerOptions = listOf(10, 12, 15)
+    val selectedTimer = remember { mutableIntStateOf(10) }
+
+    val notificationsEnabled = remember { mutableStateOf(false) }
+    val selectedTime = remember { mutableStateOf(LocalTime.now()) }
+
+    val showTimePicker = remember { mutableStateOf(false) }
+
+    if (showTimePicker.value) {
+        TimePickerDialog(
+            initialTime = selectedTime.value,
+            onCancel = { showTimePicker.value = false },
+            onConfirm = {
+                selectedTime.value = it
+                showTimePicker.value = false
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = { DefaultTopBar(onNavigateBackUp = onNavigateBackUp) },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                LabeledNumberInput("Standard Study Card Limit", standardLimit.value) {
+                    standardLimit.value = it
+                }
+                LabeledNumberInput("Timed Study Card Limit", timedLimit.value) {
+                    timedLimit.value = it
+                }
+                LabeledNumberInput("Advanced Study Card Limit", advancedLimit.value) {
+                    advancedLimit.value = it
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Study Timer", style = MaterialTheme.typography.bodyLarge, textAlign = TextAlign.Center)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    timerOptions.forEach { option ->
+                        FilterChip(
+                            selected = selectedTimer.intValue == option,
+                            onClick = { selectedTimer.intValue = option },
+                            label = { Text("$option") }
+                        )
+                    }
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Daily Notifications", style = MaterialTheme.typography.bodyLarge)
+                    Switch(
+                        checked = notificationsEnabled.value,
+                        onCheckedChange = { notificationsEnabled.value = it }
+                    )
+                }
+
+                AnimatedVisibility(visible = notificationsEnabled.value) {
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Time", style = MaterialTheme.typography.bodyLarge)
+
+                        Text(
+                            text = selectedTime.value.format(DateTimeFormatter.ofPattern("HH:mm")),
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier
+                                .background(
+                                    MaterialTheme.colorScheme.primaryContainer,
+                                    RoundedCornerShape(8.dp)
+                                )
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .clickable { showTimePicker.value = true },
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { /* Save logic */ },
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .fillMaxWidth(0.5f),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text("Save")
+            }
+        }
+    }
+}
+
+@Composable
+fun LabeledNumberInput(label: String, value: String, onValueChange: (String) -> Unit) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { if (it.all { c -> c.isDigit() }) onValueChange(it) },
+        label = { Text(label) },
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimePickerDialog(
+    initialTime: LocalTime,
+    onCancel: () -> Unit,
+    onConfirm: (LocalTime) -> Unit
+) {
+    val state = rememberTimePickerState(
+        initialHour = initialTime.hour,
+        initialMinute = initialTime.minute,
+        is24Hour = true
+    )
+
+    AlertDialog(
+        onDismissRequest = onCancel,
+        title = {
+            Text("Select Time", style = MaterialTheme.typography.titleLarge)
+        },
+        text = {
+            TimeInput(state = state)
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val newTime = LocalTime.of(state.hour, state.minute)
+                onConfirm(newTime)
+            }) {
+                Text("Confirm")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onCancel) {
+                Text("Cancel")
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+        titleContentColor = MaterialTheme.colorScheme.onSurface,
+        textContentColor = MaterialTheme.colorScheme.onSurface
+    )
+}

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
@@ -182,7 +182,7 @@ fun SettingsScreen(
                         viewModel.updateUiState(uiState.copy(standardLimit = it))
                     },
                     selectedNumber = uiState.standardLimit,
-                    range = SettingsViewModel.DEFAULT_RANGE,
+                    range = SettingsDefaults.DEFAULT_RANGE,
                     showDialog = showDialogStandard
                 )
 
@@ -192,7 +192,7 @@ fun SettingsScreen(
                         viewModel.updateUiState(uiState.copy(timedLimit = it))
                     },
                     selectedNumber = uiState.timedLimit,
-                    range = SettingsViewModel.DEFAULT_RANGE,
+                    range = SettingsDefaults.DEFAULT_RANGE,
                     showDialog = showDialogTimed
                 )
 
@@ -202,7 +202,7 @@ fun SettingsScreen(
                         viewModel.updateUiState(uiState.copy(advancedLimit = it))
                     },
                     selectedNumber = uiState.advancedLimit,
-                    range = SettingsViewModel.DEFAULT_RANGE,
+                    range = SettingsDefaults.DEFAULT_RANGE,
                     showDialog = showDialogAdvanced
                 )
             }

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
@@ -5,11 +5,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -18,6 +20,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -28,6 +33,9 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,6 +46,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.flashcardsapp.R
 import com.example.flashcardsapp.ui.DefaultTopBar
 import com.example.flashcardsapp.ui.FlashCardAppViewModelProvider
+import kotlinx.coroutines.launch
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
@@ -47,28 +56,40 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = viewModel(factory = FlashCardAppViewModelProvider.Factory)
 ) {
     val uiState by viewModel.settingsUiState
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     val showDialogStandard = remember { mutableStateOf(false) }
     val showDialogTimed = remember { mutableStateOf(false) }
     val showDialogAdvanced = remember { mutableStateOf(false) }
 
     val timerOptions = listOf(10, 12, 15)
-    val selectedTime = remember { mutableStateOf(LocalTime.now()) }
-    val showTimePicker = remember { mutableStateOf(false) }
+    val selectedTime by rememberUpdatedState(uiState.notificationsLocalTime ?: LocalTime.now())
+    var showTimePicker by remember { mutableStateOf(false) }
 
-    if (showTimePicker.value) {
+    val dateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+    if (showTimePicker) {
         TimePickerDialog(
-            initialTime = selectedTime.value,
-            onCancel = { showTimePicker.value = false },
+            initialTime = selectedTime,
+            onCancel = { showTimePicker = false },
             onConfirm = {
-                selectedTime.value = it
-                showTimePicker.value = false
+                viewModel.updateUiState(uiState.copy(notificationsTime = it.format(dateTimeFormatter)))
+                showTimePicker = false
             }
         )
     }
 
     Scaffold(
-        topBar = { DefaultTopBar(onNavigateBackUp = onNavigateBackUp) },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState, modifier = Modifier.imePadding())
+        },
+        topBar = {
+            DefaultTopBar(
+                text = stringResource(R.string.settings),
+                onNavigateBackUp = onNavigateBackUp
+            )
+        },
         containerColor = MaterialTheme.colorScheme.background
     ) { padding ->
         Column(
@@ -80,32 +101,32 @@ fun SettingsScreen(
         ) {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 StudyCardLimitPicker(
-                    text = "Standard Study Card Limit",
+                    text = stringResource(R.string.standard_study_card_limit),
                     onValueChange = {
                         viewModel.updateUiState(uiState.copy(standardLimit = it))
                     },
                     selectedNumber = uiState.standardLimit,
-                    range = 5..20,
+                    range = SettingsViewModel.DEFAULT_RANGE,
                     showDialog = showDialogStandard
                 )
 
                 StudyCardLimitPicker(
-                    text = "Timed Study Card Limit",
+                    text = stringResource(R.string.timed_study_card_limit),
                     onValueChange = {
                         viewModel.updateUiState(uiState.copy(timedLimit = it))
                     },
                     selectedNumber = uiState.timedLimit,
-                    range = 5..20,
+                    range = SettingsViewModel.DEFAULT_RANGE,
                     showDialog = showDialogTimed
                 )
 
                 StudyCardLimitPicker(
-                    text = "Advanced Study Card Limit",
+                    text = stringResource(R.string.advanced_study_card_limit),
                     onValueChange = {
                         viewModel.updateUiState(uiState.copy(advancedLimit = it))
                     },
                     selectedNumber = uiState.advancedLimit,
-                    range = 5..20,
+                    range = SettingsViewModel.DEFAULT_RANGE,
                     showDialog = showDialogAdvanced
                 )
             }
@@ -116,7 +137,7 @@ fun SettingsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "Study Timer",
+                    text = stringResource(R.string.study_timer),
                     style = MaterialTheme.typography.bodyLarge,
                     textAlign = TextAlign.Center
                 )
@@ -139,7 +160,7 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text("Daily Notifications", style = MaterialTheme.typography.bodyLarge)
+                    Text(text = stringResource(R.string.daily_notifications), style = MaterialTheme.typography.bodyLarge)
                     Switch(
                         checked = uiState.notificationsEnabled,
                         onCheckedChange = {
@@ -154,19 +175,24 @@ fun SettingsScreen(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        Text("Time", style = MaterialTheme.typography.bodyLarge)
+                        Text(text = stringResource(R.string.time), style = MaterialTheme.typography.bodyLarge)
 
-                        Text(
-                            text = selectedTime.value.format(DateTimeFormatter.ofPattern("HH:mm")),
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        Box(
                             modifier = Modifier
+                                .clickable { showTimePicker = true }
                                 .background(
-                                    MaterialTheme.colorScheme.primaryContainer,
-                                    RoundedCornerShape(8.dp)
+                                    color = MaterialTheme.colorScheme.primaryContainer,
+                                    shape = RoundedCornerShape(8.dp)
                                 )
                                 .padding(horizontal = 16.dp, vertical = 8.dp)
-                                .clickable { showTimePicker.value = true },
-                        )
+                        ) {
+                            Text(
+                                text = selectedTime.format(dateTimeFormatter),
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        }
                     }
                 }
             }
@@ -175,14 +201,24 @@ fun SettingsScreen(
 
             Button(
                 onClick = {
+                    coroutineScope.launch {
+                        val selectedTimeParsed = selectedTime.format(dateTimeFormatter)
+                        viewModel.updateUiState(uiState.copy(notificationsTime = selectedTimeParsed))
+                        viewModel.updateSettings(uiState)
 
+                        snackbarHostState.showSnackbar(
+                            message = "Saved settings",
+                            duration = SnackbarDuration.Short
+                        )
+                        onNavigateBackUp()
+                    }
                 },
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .fillMaxWidth(0.5f),
                 shape = RoundedCornerShape(12.dp)
             ) {
-                Text("Save")
+                Text(text = stringResource(R.string.save))
             }
         }
     }
@@ -213,17 +249,23 @@ private fun StudyCardLimitPicker(
             range = range,
             onValueChange = onValueChange,
         )
-        Text(
-            text = selectedNumber.toString(),
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
+
+        Box(
             modifier = Modifier
+                .clickable { showDialog.value = true }
                 .background(
-                    MaterialTheme.colorScheme.primaryContainer,
-                    RoundedCornerShape(8.dp)
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(8.dp)
                 )
                 .padding(horizontal = 16.dp, vertical = 8.dp)
-                .clickable { showDialog.value = true },
-        )
+        ) {
+            Text(
+                text = selectedNumber.toString(),
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
     }
 }
 
@@ -243,7 +285,7 @@ fun TimePickerDialog(
     AlertDialog(
         onDismissRequest = onCancel,
         title = {
-            Text("Select Time", style = MaterialTheme.typography.titleLarge)
+            Text(text = stringResource(R.string.select_time), style = MaterialTheme.typography.titleLarge)
         },
         text = {
             TimeInput(state = state)

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsScreen.kt
@@ -60,6 +60,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.flashcardsapp.R
 import com.example.flashcardsapp.ui.DefaultTopBar
 import com.example.flashcardsapp.ui.FlashCardAppViewModelProvider
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -85,6 +86,9 @@ fun SettingsScreen(
     val requestPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
             viewModel.updateUiState(uiState.copy(notificationsEnabled = it, notificationPermGranted = it))
+            if (it) {
+                viewModel.scheduleNotificationDefaultTime()
+            }
         }
 
     val dateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
@@ -101,6 +105,12 @@ fun SettingsScreen(
             if (intentToEnableNotifications) {
                 viewModel.updateUiState(uiState.copy(notificationsEnabled = it))
                 intentToEnableNotifications = false
+
+                // delay scheduling the notification on resume because system might not be ready
+                coroutineScope.launch {
+                    delay(100)
+                    viewModel.scheduleNotificationDefaultTime()
+                }
             }
         }
     )

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.time.LocalTime
 
 private val Context.dataStore by preferencesDataStore(name = "settings")
 
@@ -24,16 +25,25 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
             val prefs = applicationContext.dataStore.data.first()
 
             if (prefs[SettingsKeys.isInitializedKey] == true) {
+                settingsUiState.value = SettingsUiState(
+                    standardLimit = prefs[SettingsKeys.standardLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
+                    timedLimit = prefs[SettingsKeys.timedLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
+                    advancedLimit = prefs[SettingsKeys.advancedLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
+                    timerSeconds = prefs[SettingsKeys.timerSecondsKey] ?: DEFAULT_TIMER_SECONDS,
+                    notificationsEnabled = prefs[SettingsKeys.notificationsEnabledKey] ?: false,
+                    notificationsTime = prefs[SettingsKeys.notificationsTimeKey] ?: DEFAULT_NOTIFICATIONS_TIME
+                )
+
                 return@launch
             }
 
             applicationContext.dataStore.edit {
-                it[SettingsKeys.standardLimitKey] = 10
-                it[SettingsKeys.timedLimitKey] = 10
-                it[SettingsKeys.advancedLimitKey] = 10
-                it[SettingsKeys.timerSecondsKey] = 10
+                it[SettingsKeys.standardLimitKey] = DEFAULT_STUDY_CARD_LIMIT
+                it[SettingsKeys.timedLimitKey] = DEFAULT_STUDY_CARD_LIMIT
+                it[SettingsKeys.advancedLimitKey] = DEFAULT_STUDY_CARD_LIMIT
+                it[SettingsKeys.timerSecondsKey] = DEFAULT_TIMER_SECONDS
                 it[SettingsKeys.notificationsEnabledKey] = false
-                it[SettingsKeys.notificationsTimeKey] = "00:00"
+                it[SettingsKeys.notificationsTimeKey] = DEFAULT_NOTIFICATIONS_TIME
                 it[SettingsKeys.isInitializedKey] = true
             }
         }
@@ -56,6 +66,12 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
         settingsUiState.value = uiState
     }
 
+    companion object {
+        val DEFAULT_RANGE = 5..20
+        private const val DEFAULT_STUDY_CARD_LIMIT = 10
+        private const val DEFAULT_TIMER_SECONDS = 10
+        private const val DEFAULT_NOTIFICATIONS_TIME = "09:00"
+    }
 }
 
 data class SettingsUiState(
@@ -64,8 +80,15 @@ data class SettingsUiState(
     val advancedLimit: Int = 10,
     val timerSeconds: Int = 10,
     val notificationsEnabled: Boolean = false,
-    val notificationsTime: String = "00:00",
-)
+    val notificationsTime: String = "09:00",
+) {
+    val notificationsLocalTime: LocalTime?
+        get() {
+            if (notificationsTime == "09:00") return null
+            val notificationTimeSplit = notificationsTime.split(':')
+            return LocalTime.of(notificationTimeSplit[0].toInt(), notificationTimeSplit[1].toInt())
+        }
+}
 
 object SettingsKeys {
     val standardLimitKey = intPreferencesKey("standard_limit")

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -71,7 +71,7 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
 
     companion object {
         val DEFAULT_RANGE = 5..20
-        private const val DEFAULT_STUDY_CARD_LIMIT = 10
+        const val DEFAULT_STUDY_CARD_LIMIT = 10
         private const val DEFAULT_TIMER_SECONDS = 10
         private const val DEFAULT_NOTIFICATIONS_TIME = "09:00"
     }

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -85,7 +85,7 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
 
     fun scheduleNotificationDefaultTime() {
         cancelNotifications()
-        ReminderNotification(applicationContext).scheduleNotificationDefaultTime()
+        ReminderNotification(applicationContext).scheduleNotification()
     }
 }
 

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,79 @@
+package com.example.flashcardsapp.ui.settings
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+private val Context.dataStore by preferencesDataStore(name = "settings")
+
+class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
+
+    var settingsUiState = mutableStateOf(SettingsUiState())
+        private set
+
+    init {
+        viewModelScope.launch {
+            val prefs = applicationContext.dataStore.data.first()
+
+            if (prefs[SettingsKeys.isInitializedKey] == true) {
+                return@launch
+            }
+
+            applicationContext.dataStore.edit {
+                it[SettingsKeys.standardLimitKey] = 10
+                it[SettingsKeys.timedLimitKey] = 10
+                it[SettingsKeys.advancedLimitKey] = 10
+                it[SettingsKeys.timerSecondsKey] = 10
+                it[SettingsKeys.notificationsEnabledKey] = false
+                it[SettingsKeys.notificationsTimeKey] = "00:00"
+                it[SettingsKeys.isInitializedKey] = true
+            }
+        }
+    }
+
+    fun updateSettings(uiState: SettingsUiState) {
+        viewModelScope.launch {
+            applicationContext.dataStore.edit {
+                it[SettingsKeys.standardLimitKey] = uiState.standardLimit
+                it[SettingsKeys.timedLimitKey] = uiState.timedLimit
+                it[SettingsKeys.advancedLimitKey] = uiState.advancedLimit
+                it[SettingsKeys.timerSecondsKey] = uiState.timerSeconds
+                it[SettingsKeys.notificationsEnabledKey] = uiState.notificationsEnabled
+                it[SettingsKeys.notificationsTimeKey] = uiState.notificationsTime
+            }
+        }
+    }
+
+    fun updateUiState(uiState: SettingsUiState) {
+        settingsUiState.value = uiState
+    }
+
+}
+
+data class SettingsUiState(
+    val standardLimit: Int = 10,
+    val timedLimit: Int = 10,
+    val advancedLimit: Int = 10,
+    val timerSeconds: Int = 10,
+    val notificationsEnabled: Boolean = false,
+    val notificationsTime: String = "00:00",
+)
+
+object SettingsKeys {
+    val standardLimitKey = intPreferencesKey("standard_limit")
+    val timedLimitKey = intPreferencesKey("timed_limit")
+    val advancedLimitKey = intPreferencesKey("advanced_limit")
+    val timerSecondsKey = intPreferencesKey("timer_seconds")
+    val notificationsEnabledKey = booleanPreferencesKey("notifications_enabled")
+    val notificationsTimeKey = stringPreferencesKey("notifications_time")
+    val hasRequestPermissionOnceKey = booleanPreferencesKey("has_requested_permission_once")
+    val isInitializedKey = booleanPreferencesKey("is_initialized")
+}

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -12,6 +12,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.flashcardsapp.notification.NotificationUtils
+import com.example.flashcardsapp.notification.ReminderNotification
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.LocalTime
@@ -62,6 +64,11 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
                 it[SettingsKeys.notificationPermissionGrantedKey] = uiState.notificationPermGranted
                 it[SettingsKeys.notificationsTimeKey] = uiState.notificationsTime
             }
+
+            cancelNotifications()
+            if (uiState.notificationsEnabled && uiState.notificationPermGranted) {
+                ReminderNotification(applicationContext).scheduleNotification(uiState.notificationsLocalTime)
+            }
         }
     }
 
@@ -69,11 +76,16 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
         settingsUiState.value = uiState
     }
 
-    companion object {
-        val DEFAULT_RANGE = 5..20
-        const val DEFAULT_STUDY_CARD_LIMIT = 10
-        private const val DEFAULT_TIMER_SECONDS = 10
-        private const val DEFAULT_NOTIFICATIONS_TIME = "09:00"
+    private fun cancelNotifications() {
+        val pendingIntent = NotificationUtils.getNotificationPendingIntent(applicationContext)
+        val alarmManager = NotificationUtils.getAlarmManager(applicationContext)
+
+        alarmManager.cancel(pendingIntent)
+    }
+
+    fun scheduleNotificationDefaultTime() {
+        cancelNotifications()
+        ReminderNotification(applicationContext).scheduleNotificationDefaultTime()
     }
 }
 

--- a/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/settings/SettingsViewModel.kt
@@ -29,24 +29,24 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
 
             if (prefs[SettingsKeys.isInitializedKey] == false) {
                 applicationContext.dataStore.edit {
-                    it[SettingsKeys.standardLimitKey] = DEFAULT_STUDY_CARD_LIMIT
-                    it[SettingsKeys.timedLimitKey] = DEFAULT_STUDY_CARD_LIMIT
-                    it[SettingsKeys.advancedLimitKey] = DEFAULT_STUDY_CARD_LIMIT
-                    it[SettingsKeys.timerSecondsKey] = DEFAULT_TIMER_SECONDS
-                    it[SettingsKeys.notificationsTimeKey] = DEFAULT_NOTIFICATIONS_TIME
+                    it[SettingsKeys.standardLimitKey] = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT
+                    it[SettingsKeys.timedLimitKey] = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT
+                    it[SettingsKeys.advancedLimitKey] = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT
+                    it[SettingsKeys.timerSecondsKey] = SettingsDefaults.DEFAULT_TIMER_SECONDS
+                    it[SettingsKeys.notificationsTimeKey] = SettingsDefaults.DEFAULT_NOTIFICATIONS_TIME
                     it[SettingsKeys.isInitializedKey] = true
                 }
             }
 
             settingsUiState.value = SettingsUiState(
-                standardLimit = prefs[SettingsKeys.standardLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
-                timedLimit = prefs[SettingsKeys.timedLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
-                advancedLimit = prefs[SettingsKeys.advancedLimitKey] ?: DEFAULT_STUDY_CARD_LIMIT,
-                timerSeconds = prefs[SettingsKeys.timerSecondsKey] ?: DEFAULT_TIMER_SECONDS,
+                standardLimit = prefs[SettingsKeys.standardLimitKey] ?: SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+                timedLimit = prefs[SettingsKeys.timedLimitKey] ?: SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+                advancedLimit = prefs[SettingsKeys.advancedLimitKey] ?: SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+                timerSeconds = prefs[SettingsKeys.timerSecondsKey] ?: SettingsDefaults.DEFAULT_TIMER_SECONDS,
                 notificationsEnabled = prefs[SettingsKeys.notificationsEnabledKey] ?: false,
                 notificationPermGranted = prefs[SettingsKeys.notificationPermissionGrantedKey] ?: false,
                 notificationsTime = prefs[SettingsKeys.notificationsTimeKey]
-                    ?: DEFAULT_NOTIFICATIONS_TIME
+                    ?: SettingsDefaults.DEFAULT_NOTIFICATIONS_TIME
             )
         }
     }
@@ -78,13 +78,13 @@ class SettingsViewModel(private val applicationContext: Context) : ViewModel() {
 }
 
 data class SettingsUiState(
-    val standardLimit: Int = 10,
-    val timedLimit: Int = 10,
-    val advancedLimit: Int = 10,
-    val timerSeconds: Int = 10,
+    val standardLimit: Int = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+    val timedLimit: Int = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+    val advancedLimit: Int = SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT,
+    val timerSeconds: Int = SettingsDefaults.DEFAULT_TIMER_SECONDS,
     val notificationsEnabled: Boolean = false,
     val notificationPermGranted: Boolean = false,
-    val notificationsTime: String = "09:00",
+    val notificationsTime: String = SettingsDefaults.DEFAULT_NOTIFICATIONS_TIME,
 ) {
     val notificationsLocalTime: LocalTime
         get() {
@@ -103,6 +103,13 @@ object SettingsKeys {
     val hasRequestPermissionOnceKey = booleanPreferencesKey("has_requested_permission_once")
     val isInitializedKey = booleanPreferencesKey("is_initialized")
     val notificationPermissionGrantedKey = booleanPreferencesKey("notification_permission_granted")
+}
+
+object SettingsDefaults {
+    val DEFAULT_RANGE = 5..20
+    const val DEFAULT_STUDY_CARD_LIMIT = 10
+    const val DEFAULT_TIMER_SECONDS = 10
+    const val DEFAULT_NOTIFICATIONS_TIME = "09:00"
 }
 
 fun Activity.openAppSettings() {

--- a/app/src/main/java/com/example/flashcardsapp/ui/study/AdvancedStudyViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/study/AdvancedStudyViewModel.kt
@@ -1,14 +1,21 @@
 package com.example.flashcardsapp.ui.study
 
+import android.content.Context
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.flashcardsapp.data.entity.Card
 import com.example.flashcardsapp.data.repository.CardRepository
+import com.example.flashcardsapp.ui.settings.SettingsKeys
+import com.example.flashcardsapp.ui.settings.SettingsViewModel
+import com.example.flashcardsapp.ui.settings.dataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class AdvancedStudyViewModel(
+    private val applicationContext: Context,
     private val deckId: Int,
     private val cardRepository: CardRepository
 ) : ViewModel() {
@@ -17,8 +24,12 @@ class AdvancedStudyViewModel(
 
     init {
         viewModelScope.launch {
+            val limit = applicationContext.dataStore.data.map {
+                it[SettingsKeys.advancedLimitKey] ?: SettingsViewModel.DEFAULT_STUDY_CARD_LIMIT
+            }.first()
+
             _advancedUiState.value = AdvancedUiState(
-                cards = cardRepository.getRandomCards(limit = 10, deckId = deckId)
+                cards = cardRepository.getRandomCards(limit = limit, deckId = deckId)
             )
         }
     }

--- a/app/src/main/java/com/example/flashcardsapp/ui/study/AdvancedStudyViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/study/AdvancedStudyViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.flashcardsapp.data.entity.Card
 import com.example.flashcardsapp.data.repository.CardRepository
+import com.example.flashcardsapp.ui.settings.SettingsDefaults
 import com.example.flashcardsapp.ui.settings.SettingsKeys
-import com.example.flashcardsapp.ui.settings.SettingsViewModel
 import com.example.flashcardsapp.ui.settings.dataStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -25,7 +25,7 @@ class AdvancedStudyViewModel(
     init {
         viewModelScope.launch {
             val limit = applicationContext.dataStore.data.map {
-                it[SettingsKeys.advancedLimitKey] ?: SettingsViewModel.DEFAULT_STUDY_CARD_LIMIT
+                it[SettingsKeys.advancedLimitKey] ?: SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT
             }.first()
 
             _advancedUiState.value = AdvancedUiState(

--- a/app/src/main/java/com/example/flashcardsapp/ui/study/StandardStudyViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/study/StandardStudyViewModel.kt
@@ -1,15 +1,22 @@
 package com.example.flashcardsapp.ui.study
 
+import android.content.Context
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.flashcardsapp.data.entity.Card
 import com.example.flashcardsapp.data.repository.CardRepository
+import com.example.flashcardsapp.ui.settings.SettingsKeys
+import com.example.flashcardsapp.ui.settings.SettingsViewModel
+import com.example.flashcardsapp.ui.settings.dataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.math.max
 
 class StandardStudyViewModel(
+    private val applicationContext: Context,
     private val deckId: Int,
     private val cardRepository: CardRepository
 ) : ViewModel() {
@@ -18,10 +25,14 @@ class StandardStudyViewModel(
 
     init {
         viewModelScope.launch {
+            val limit = applicationContext.dataStore.data.map {
+                it[SettingsKeys.standardLimitKey] ?: SettingsViewModel.DEFAULT_STUDY_CARD_LIMIT
+            }.first()
+
             _standardUiState.value = StandardUiState(
                 cards = cardRepository.getDueCardsFromDeck(
                     currentTime = System.currentTimeMillis(),
-                    limit = 10,
+                    limit = limit,
                     deckId = deckId
                 )
             )

--- a/app/src/main/java/com/example/flashcardsapp/ui/study/StandardStudyViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/study/StandardStudyViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.flashcardsapp.data.entity.Card
 import com.example.flashcardsapp.data.repository.CardRepository
+import com.example.flashcardsapp.ui.settings.SettingsDefaults
 import com.example.flashcardsapp.ui.settings.SettingsKeys
-import com.example.flashcardsapp.ui.settings.SettingsViewModel
 import com.example.flashcardsapp.ui.settings.dataStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -26,7 +26,7 @@ class StandardStudyViewModel(
     init {
         viewModelScope.launch {
             val limit = applicationContext.dataStore.data.map {
-                it[SettingsKeys.standardLimitKey] ?: SettingsViewModel.DEFAULT_STUDY_CARD_LIMIT
+                it[SettingsKeys.standardLimitKey] ?: SettingsDefaults.DEFAULT_STUDY_CARD_LIMIT
             }.first()
 
             _standardUiState.value = StandardUiState(

--- a/app/src/main/java/com/example/flashcardsapp/ui/study/TimedStudyViewModel.kt
+++ b/app/src/main/java/com/example/flashcardsapp/ui/study/TimedStudyViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.flashcardsapp.ui.study
 
+import android.content.Context
 import android.os.CountDownTimer
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableFloatStateOf
@@ -9,10 +10,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.flashcardsapp.data.entity.Card
 import com.example.flashcardsapp.data.repository.CardRepository
+import com.example.flashcardsapp.ui.settings.SettingsKeys
+import com.example.flashcardsapp.ui.settings.SettingsViewModel
+import com.example.flashcardsapp.ui.settings.dataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 class TimedStudyViewModel(
+    private val applicationContext: Context,
     private val deckId: Int,
     private val cardRepository: CardRepository
 ) : ViewModel() {
@@ -21,8 +28,12 @@ class TimedStudyViewModel(
 
     init {
         viewModelScope.launch {
+            val limit = applicationContext.dataStore.data.map {
+                it[SettingsKeys.timedLimitKey] ?: SettingsViewModel.DEFAULT_STUDY_CARD_LIMIT
+            }.first()
+
             _timedUiState.value = TimedUiState(
-                cards = cardRepository.getRandomCards(limit = 10, deckId = deckId)
+                cards = cardRepository.getRandomCards(limit = limit, deckId = deckId)
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,6 @@
     <string name="daily_notifications">Daily Notifications</string>
     <string name="time">Time</string>
     <string name="select_time">Select Time</string>
+    <string name="notifications">Notifications</string>
+    <string name="grant_permissions">Grant Permissions</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,12 @@
     <string name="not_selected_deck_icon">Not Selected Deck Icon</string>
     <string name="selected_deck_icon">Selected Deck Icon</string>
     <string name="settings_icon">Settings Icon</string>
+    <string name="settings">Settings</string>
+    <string name="standard_study_card_limit">Standard Study Card Limit</string>
+    <string name="timed_study_card_limit">Timed Study Card Limit</string>
+    <string name="advanced_study_card_limit">Advanced Study Card Limit</string>
+    <string name="study_timer">Study Timer</string>
+    <string name="daily_notifications">Daily Notifications</string>
+    <string name="time">Time</string>
+    <string name="select_time">Select Time</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="delete_warning_icon">Delete Warning Icon</string>
     <string name="not_selected_deck_icon">Not Selected Deck Icon</string>
     <string name="selected_deck_icon">Selected Deck Icon</string>
+    <string name="settings_icon">Settings Icon</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.2"
+datastorePreferences = "1.1.4"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -15,6 +16,7 @@ uiTextGoogleFonts = "1.7.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomKtx" }


### PR DESCRIPTION
Add settings and improve how notifications are handled, mainly:
- When app is first launched, user is asked for notifications permission. If denied, a rationale (dialog) is shown telling them they can always enable notifications in settings.
- When in settings and trying to enable notifications, user is again asked for permission (if not previously granted). If denied again, a rationale is shown telling them to enable notifications from phone settings.
- In both cases, if user permits notifications, a default notification is scheduled for 09:00 (configurable in app settings) o'clock every day.